### PR TITLE
Adjust application clock precision to that of PostgreSQL

### DIFF
--- a/src/main/java/io/github/akuniutka/config/ApplicationConfig.java
+++ b/src/main/java/io/github/akuniutka/config/ApplicationConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 
 import java.time.Clock;
+import java.time.Duration;
 
 @Configuration
 @PropertySource("classpath:application.properties")
@@ -14,6 +15,7 @@ public class ApplicationConfig {
 
     @Bean
     public Clock clock() {
-        return Clock.systemDefaultZone();
+        // Adjust application clock precision to that of PostgreSQL (1 microsecond)
+        return Clock.tick(Clock.systemDefaultZone(), Duration.ofNanos(1_000));
     }
 }

--- a/src/test/java/io/github/akuniutka/config/ApplicationTestConfig.java
+++ b/src/test/java/io/github/akuniutka/config/ApplicationTestConfig.java
@@ -6,7 +6,7 @@ import java.time.ZoneId;
 
 public class ApplicationTestConfig {
 
-    public static final Instant FIXED_TIME = Instant.parse("2001-02-03T04:05:06.789Z");
+    public static final Instant FIXED_TIME = Instant.parse("2001-02-03T04:05:06.789012Z");
 
     public static Clock fixedClock() {
         return Clock.fixed(FIXED_TIME, ZoneId.of("Z"));

--- a/src/test/java/io/github/akuniutka/user/TestUser.java
+++ b/src/test/java/io/github/akuniutka/user/TestUser.java
@@ -17,7 +17,7 @@ public final class TestUser {
     public static final String UPPERCASE_EMAIL = EMAIL.toUpperCase();
     public static final User.State STATE = User.State.ACTIVE;
     public static final Instant REGISTRATION_DATE = ApplicationTestConfig.FIXED_TIME;
-    public static final Timestamp MODIFIED = Timestamp.from(Instant.parse("2002-03-04T05:06:07.890Z"));
+    public static final Timestamp MODIFIED = Timestamp.from(Instant.parse("2002-03-04T05:06:07.890123Z"));
     public static final String OTHER_FIRST_NAME = "Jack";
     public static final String OTHER_LAST_NAME = "Sparrow";
     public static final String OTHER_EMAIL = "jack@mail.com";

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,3 +1,3 @@
 INSERT INTO users (id, first_name, last_name, email, state, registration_date, modified)
-VALUES ('92f08b0a-4302-40ff-823d-b9ce18522552', 'John', 'Doe', 'john@mail.com', 'ACTIVE', '2001-02-03T04:05:06.789Z', '2002-03-04T05:06:07.890Z'),
-       ('a8798e28-61bb-4c0c-b906-4076ee9ddb5d', 'Jack', 'Sparrow', 'jack@mail.com', 'BLOCKED', '2003-04-05T06:07:08.901Z', '2004-05-06T07:08:09.012Z''');
+VALUES ('92f08b0a-4302-40ff-823d-b9ce18522552', 'John', 'Doe', 'john@mail.com', 'ACTIVE', '2001-02-03T04:05:06.789012Z', '2002-03-04T05:06:07.890123Z'),
+       ('a8798e28-61bb-4c0c-b906-4076ee9ddb5d', 'Jack', 'Sparrow', 'jack@mail.com', 'BLOCKED', '2003-04-05T06:07:08.901234Z', '2004-05-06T07:08:09.012345Z''');

--- a/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/create_user.json
+++ b/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/create_user.json
@@ -4,5 +4,5 @@
   "lastName": "Doe",
   "email": "john@mail.com",
   "state": "ACTIVE",
-  "registrationDate": "2001-02-03T04:05:06.789Z"
+  "registrationDate": "2001-02-03T04:05:06.789012Z"
 }

--- a/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/delete_user.json
+++ b/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/delete_user.json
@@ -4,5 +4,5 @@
   "lastName": "Doe",
   "email": "john@mail.com",
   "state": "DELETED",
-  "registrationDate": "2001-02-03T04:05:06.789Z"
+  "registrationDate": "2001-02-03T04:05:06.789012Z"
 }

--- a/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/find_all_users.json
+++ b/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/find_all_users.json
@@ -5,6 +5,6 @@
     "lastName": "Doe",
     "email": "john@mail.com",
     "state": "ACTIVE",
-    "registrationDate": "2001-02-03T04:05:06.789Z"
+    "registrationDate": "2001-02-03T04:05:06.789012Z"
   }
 ]

--- a/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/get_user_by_id.json
+++ b/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/get_user_by_id.json
@@ -4,5 +4,5 @@
   "lastName": "Doe",
   "email": "john@mail.com",
   "state": "ACTIVE",
-  "registrationDate": "2001-02-03T04:05:06.789Z"
+  "registrationDate": "2001-02-03T04:05:06.789012Z"
 }

--- a/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/update_user.json
+++ b/src/test/resources/io/github/akuniutka/user/controller/usercontrollerit/responses/update_user.json
@@ -4,5 +4,5 @@
   "lastName": "Sparrow",
   "email": "jack@mail.com",
   "state": "BLOCKED",
-  "registrationDate": "2001-02-03T04:05:06.789Z"
+  "registrationDate": "2001-02-03T04:05:06.789012Z"
 }


### PR DESCRIPTION
Adjust application clock precision to precision of TIMESTAMP data type in PostgreSQL (1 microsecond). Otherwise, `registrationDate` for newly created user may have 1 nanosecond precision on Linux until that user is reloaded from database.