### PR TITLE
Extract transforming of user properties from UserServiceImpl

### DIFF
--- a/src/main/java/io/github/akuniutka/user/service/UserInitializer.java
+++ b/src/main/java/io/github/akuniutka/user/service/UserInitializer.java
@@ -1,0 +1,11 @@
+package io.github.akuniutka.user.service;
+
+import io.github.akuniutka.user.entity.User;
+
+public interface UserInitializer {
+
+    /**
+     * Sets initials values for user's required properties.
+     */
+    void initUserProperties(User user);
+}

--- a/src/main/java/io/github/akuniutka/user/service/UserInitializerImpl.java
+++ b/src/main/java/io/github/akuniutka/user/service/UserInitializerImpl.java
@@ -1,0 +1,22 @@
+package io.github.akuniutka.user.service;
+
+import io.github.akuniutka.user.entity.User;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class UserInitializerImpl implements UserInitializer {
+
+    private final Clock clock;
+
+    @Override
+    public void initUserProperties(@NonNull final User user) {
+        user.setState(User.State.ACTIVE);
+        user.setRegistrationDate(Instant.now(clock));
+    }
+}

--- a/src/main/java/io/github/akuniutka/user/service/UserPatcher.java
+++ b/src/main/java/io/github/akuniutka/user/service/UserPatcher.java
@@ -5,14 +5,12 @@ import io.github.akuniutka.user.entity.User;
 public interface UserPatcher {
 
     /**
-     * For each {@code user}'s property sets its value to that of the relative property in the {@code patch}
-     * when the value of the property in the {@code patch} is not null and differs from the current value of
-     * {@code user}'s property.
+     * For each user's property sets its value to that of the relative property in the patch when the value of the
+     * property in the patch is not null and differs from the current value of user's property.
      *
-     * @param patch the patch to be applied to the {@code user}
+     * @param patch the patch to be applied to the user
      * @param user  the user to be updated
-     * @return {@code true} if any of {@code user}'s properties has changed in the result of update and {@code false}
-     * otherwise
+     * @return {@code true} if any of user's properties has changed in the result of update, and {@code false} otherwise
      */
     boolean applyPatchToUser(User patch, User user);
 }

--- a/src/main/java/io/github/akuniutka/user/service/UserRemover.java
+++ b/src/main/java/io/github/akuniutka/user/service/UserRemover.java
@@ -1,0 +1,14 @@
+package io.github.akuniutka.user.service;
+
+import io.github.akuniutka.user.entity.User;
+
+public interface UserRemover {
+
+    /**
+     * Marks the user as deleted.
+     *
+     * @param user the user to be deleted
+     * @return {@code true} if the user has not been marked as deleted before, and {@code false} otherwise
+     */
+    boolean markUserAsDeleted(User user);
+}

--- a/src/main/java/io/github/akuniutka/user/service/UserRemoverImpl.java
+++ b/src/main/java/io/github/akuniutka/user/service/UserRemoverImpl.java
@@ -1,0 +1,18 @@
+package io.github.akuniutka.user.service;
+
+import io.github.akuniutka.user.entity.User;
+import lombok.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserRemoverImpl implements UserRemover {
+
+    @Override
+    public boolean markUserAsDeleted(@NonNull final User user) {
+        if (user.getState() == User.State.DELETED) {
+            return false;
+        }
+        user.setState(User.State.DELETED);
+        return true;
+    }
+}

--- a/src/test/java/io/github/akuniutka/user/service/UserInitializerImplTest.java
+++ b/src/test/java/io/github/akuniutka/user/service/UserInitializerImplTest.java
@@ -1,0 +1,51 @@
+package io.github.akuniutka.user.service;
+
+import io.github.akuniutka.config.ApplicationTestConfig;
+import io.github.akuniutka.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+
+@DisplayName("UserInitializerImpl Unit Tests")
+class UserInitializerImplTest {
+
+    private static final Clock CLOCK = ApplicationTestConfig.fixedClock();
+    private static final Instant NOW = ApplicationTestConfig.FIXED_TIME;
+
+    private final UserInitializer initializer = new UserInitializerImpl(CLOCK);
+
+    @DisplayName("""
+            Given a user is null,
+            when init users's properties,
+            then throw an exception
+            """)
+    @Test
+    void givenUserIsNull_WhenInitUserProperties_ThenThrowIllegalArgumentException() {
+
+        final Throwable throwable = catchThrowable(() -> initializer.initUserProperties(null));
+
+        then(throwable)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("user is marked non-null but is null");
+    }
+
+    @DisplayName("""
+            Given a user is not null,
+            when init user's properties,
+            then set user's state to ACTIVE and registration date to now
+            """)
+    @Test
+    void givenUserNotNull_WhenInitUserProperties_ThenSetUserStateToActiveAndRegistrationDateToNow() {
+        final User user = new User();
+
+        initializer.initUserProperties(user);
+
+        then(user.getState()).isEqualTo(User.State.ACTIVE);
+        then(user.getRegistrationDate()).isEqualTo(NOW);
+    }
+}

--- a/src/test/java/io/github/akuniutka/user/service/UserPatcherImplTest.java
+++ b/src/test/java/io/github/akuniutka/user/service/UserPatcherImplTest.java
@@ -5,6 +5,15 @@ import io.github.akuniutka.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static io.github.akuniutka.user.TestUser.EMAIL;
+import static io.github.akuniutka.user.TestUser.FIRST_NAME;
+import static io.github.akuniutka.user.TestUser.ID;
+import static io.github.akuniutka.user.TestUser.LAST_NAME;
+import static io.github.akuniutka.user.TestUser.OTHER_EMAIL;
+import static io.github.akuniutka.user.TestUser.OTHER_FIRST_NAME;
+import static io.github.akuniutka.user.TestUser.OTHER_LAST_NAME;
+import static io.github.akuniutka.user.TestUser.OTHER_STATE;
+import static io.github.akuniutka.user.TestUser.STATE;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -44,178 +53,149 @@ class UserPatcherImplTest {
     }
 
     @DisplayName("""
-            Given a patch contains new values for all properties and a user is not null,
-            when apply the patch to the user,
-            then update user's properties and return true
-            """)
-    @Test
-    void givenPatchContainNewValuesForAllProperties_WhenApply_ThenUpdatePropertiesAndReturnTrue() {
-        final User user = TestUser.persisted();
-        final User patch = TestUser.patch();
-
-        final boolean isUpdated = patcher.applyPatchToUser(patch, user);
-
-        then(isUpdated).isTrue();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.patched());
-    }
-
-    @DisplayName("""
-            Given a patch contains old values for all properties and a user is not null,
-            when apply the patch to the user,
-            then do not change user's properties and return false
-            """)
-    @Test
-    void whenPatchContainOldValuesForAllProperties_WhenApply_ThenDoNotChangePropertiesAndReturnFalse() {
-        final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithOldValues();
-
-        final boolean isUpdated = patcher.applyPatchToUser(patch, user);
-
-        then(isUpdated).isFalse();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.persisted());
-    }
-
-    @DisplayName("""
             Given a patch contains null for all properties and a user is not null,
             when apply the patch to the user,
-            then do not change user's properties and return false
+            then return false
             """)
     @Test
-    void whenPatchContainNullForAllProperties_WhenApply_ThenDoNotChangePropertiesAndReturnFalse() {
+    void whenPatchContainNullForAllProperties_WhenApply_ThenReturnFalse() {
         final User user = TestUser.persisted();
         final User patch = TestUser.patchWithEmptyFields();
 
         final boolean isUpdated = patcher.applyPatchToUser(patch, user);
 
         then(isUpdated).isFalse();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.persisted());
     }
 
     @DisplayName("""
-            Given a patch contains a new first name only and a user is not null,
+            Given a patch contains the old first name and a user is not null,
             when apply the patch to the user,
-            then update user's first name only and return true
+            then return false
             """)
     @Test
-    void whenPatchContainNewFirstNameOnly_WhenApply_ThenUpdateFirstNameOnlyAndReturnTrue() {
+    void whenPatchContainOldFirstName_WhenApply_ThenDoReturnFalse() {
         final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithNewFirstNameOnly();
-
-        final boolean isUpdated = patcher.applyPatchToUser(patch, user);
-
-        then(isUpdated).isTrue();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.patchedWithFirstNameOnly());
-    }
-
-    @DisplayName("""
-            Given a patch contains the old first name only and a user is not null,
-            when apply the patch to the user,
-            then do not change user's properties and return false
-            """)
-    @Test
-    void whenPatchContainOldFirstNameOnly_WhenApply_ThenDoNotChangePropertiesAndReturnFalse() {
-        final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithOldFirstNameOnly();
+        final User patch = new User(ID);
+        patch.setFirstName(FIRST_NAME);
 
         final boolean isUpdated = patcher.applyPatchToUser(patch, user);
 
         then(isUpdated).isFalse();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.persisted());
     }
 
     @DisplayName("""
-            Given a patch contains a new last name only and a user is not null,
+            Given a patch contains a new first name and a user is not null,
             when apply the patch to the user,
-            then user's last name only and return true
+            then update user's first name and return true
             """)
     @Test
-    void givenPatchContainNewLastNameOnly_WhenApply_ThenUpdateLastNameOnlyAndReturnTrue() {
+    void whenPatchContainNewFirstName_WhenApply_ThenUpdateFirstNameAndReturnTrue() {
         final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithNewLastNameOnly();
+        final User patch = new User(ID);
+        patch.setFirstName(OTHER_FIRST_NAME);
 
         final boolean isUpdated = patcher.applyPatchToUser(patch, user);
 
         then(isUpdated).isTrue();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.patchedWithLastNameOnly());
+        then(user.getFirstName()).isEqualTo(OTHER_FIRST_NAME);
     }
 
     @DisplayName("""
-            Given a patch contains an old last name only and a user is not null,
+            Given a patch contains the old last name and a user is not null,
             when apply the patch to the user,
-            then do not change user's properties and return false
+            then return false
             """)
     @Test
-    void givenPatchContainOldLastNameOnly_WhenApply_ThenDoNotChangePropertiesAndReturnFalse() {
+    void givenPatchContainOldLastName_WhenApply_ThenReturnFalse() {
         final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithOldLastNameOnly();
+        final User patch = new User(ID);
+        patch.setLastName(LAST_NAME);
 
         final boolean isUpdated = patcher.applyPatchToUser(patch, user);
 
         then(isUpdated).isFalse();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.persisted());
     }
 
     @DisplayName("""
-            Given a patch contains a new email only and a user not is null,
+            Given a patch contains a new last name and a user is not null,
             when apply the patch to the user,
-            then update user's email only and return true
+            then update user's last name and return true
             """)
     @Test
-    void givenPatchContainNewEmailOnly_WhenApply_ThenUpdateEmailOnlyAndReturnTrue() {
+    void givenPatchContainNewLastName_WhenApply_ThenUpdateLastNameAndReturnTrue() {
         final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithNewEmailOnly();
+        final User patch = new User(ID);
+        patch.setLastName(OTHER_LAST_NAME);
 
         final boolean isUpdated = patcher.applyPatchToUser(patch, user);
 
         then(isUpdated).isTrue();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.patchedWithNewEmailOnly());
+        then(user.getLastName()).isEqualTo(OTHER_LAST_NAME);
     }
 
     @DisplayName("""
-            Given a patch contains an old email only and a user is not null,
+            Given a patch contains the old email and a user is not null,
             when apply the patch to the user,
-            then do not change user's properties and return false
+            then return false
             """)
     @Test
-    void givenPatchContainOldEmailOnly_WhenApply_ThenDoNotChangePropertiesAndReturnFalse() {
+    void givenPatchContainOldEmail_WhenApply_ThenReturnFalse() {
         final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithOldEmailOnly();
+        final User patch = new User(ID);
+        user.setEmail(EMAIL);
 
         final boolean isUpdated = patcher.applyPatchToUser(patch, user);
 
         then(isUpdated).isFalse();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.persisted());
     }
 
     @DisplayName("""
-            Given a patch contains a new state only and a user is not null,
+            Given a patch contains a new email and a user not is null,
+            when apply the patch to the user,
+            then update user's email and return true
+            """)
+    @Test
+    void givenPatchContainNewEmail_WhenApply_ThenUpdateEmailAndReturnTrue() {
+        final User user = TestUser.persisted();
+        final User patch = new User(ID);
+        patch.setEmail(OTHER_EMAIL);
+
+        final boolean isUpdated = patcher.applyPatchToUser(patch, user);
+
+        then(isUpdated).isTrue();
+        then(user.getEmail()).isEqualTo(OTHER_EMAIL);
+    }
+
+    @DisplayName("""
+            Given a patch contains the old state and a user is not null,
+            when apply the patch to the user,
+            then return false
+            """)
+    @Test
+    void givenPatchContainOldState_WhenApply_ThenReturnFalse() {
+        final User user = TestUser.persisted();
+        final User patch = new User(ID);
+        patch.setState(STATE);
+
+        final boolean isUpdated = patcher.applyPatchToUser(patch, user);
+
+        then(isUpdated).isFalse();
+    }
+
+    @DisplayName("""
+            Given a patch contains a new state and a user is not null,
             when apply the patch to the user,
             then update user's state and return true
             """)
     @Test
-    void givenPatchContainNewStateOnly_WhenApply_ThenUpdateStateOnlyAndReturnTrue() {
+    void givenPatchContainNewState_WhenApply_ThenUpdateStateAndReturnTrue() {
         final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithNewStateOnly();
+        final User patch = new User(ID);
+        patch.setState(OTHER_STATE);
 
         final boolean isUpdated = patcher.applyPatchToUser(patch, user);
 
         then(isUpdated).isTrue();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.patchedWithStateOnly());
-    }
-
-    @DisplayName("""
-            Given a patch contains an old state only and a user is not null,
-            when apply the patch to the user,
-            then do not change user's properties and return false
-            """)
-    @Test
-    void givenPatchContainOldStateOnly_WhenApply_ThenDoNotChangePropertiesAndReturnFalse() {
-        final User user = TestUser.persisted();
-        final User patch = TestUser.patchWithOldStateOnly();
-
-        final boolean isUpdated = patcher.applyPatchToUser(patch, user);
-
-        then(isUpdated).isFalse();
-        then(user).usingRecursiveComparison().isEqualTo(TestUser.persisted());
+        then(user.getState()).isEqualTo(OTHER_STATE);
     }
 }

--- a/src/test/java/io/github/akuniutka/user/service/UserRemoverImplTest.java
+++ b/src/test/java/io/github/akuniutka/user/service/UserRemoverImplTest.java
@@ -1,0 +1,59 @@
+package io.github.akuniutka.user.service;
+
+import io.github.akuniutka.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+
+@DisplayName("UserRemoverImpl Unit Tests")
+class UserRemoverImplTest {
+
+    private final UserRemover remover = new UserRemoverImpl();
+
+    @DisplayName("""
+            Given a user is null,
+            when mark the user as deleted,
+            then throw an exception
+            """)
+    @Test
+    void givenUserIsNull_WhenMarkUserAsDeleted_ThenThrowIllegalArgumentException() {
+
+        final Throwable throwable = catchThrowable(() -> remover.markUserAsDeleted(null));
+
+        then(throwable)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("user is marked non-null but is null");
+    }
+
+    @DisplayName("""
+            Given a user is deleted,
+            when mark the user as deleted,
+            then do not change the user's properties, and return false
+            """)
+    @Test
+    void givenUserAlreadyDeleted_WhenMarkUserAsDeleted_ThenReturnFalse() {
+        final User user = new User();
+        user.setState(User.State.DELETED);
+
+        final boolean hasChanges = remover.markUserAsDeleted(user);
+
+        then(hasChanges).isFalse();
+    }
+
+    @DisplayName("""
+            Given a user is not deleted,
+            when mark the user as deleted,
+            then change user's state to DELETE, and return true
+            """)
+    @Test
+    void givenUserNotDeleted_WhenMarkUserAsDeleted_ThenChangeUserStateToDeletedAndReturnTrue() {
+        final User user = new User();
+
+        final boolean hasChanges = remover.markUserAsDeleted(user);
+
+        then(hasChanges).isTrue();
+        then(user.getState()).isEqualTo(User.State.DELETED);
+    }
+}

--- a/src/test/resources/io/github/akuniutka/user/service/deleteuserbyidtest/delete_already_deleted_user.json
+++ b/src/test/resources/io/github/akuniutka/user/service/deleteuserbyidtest/delete_already_deleted_user.json
@@ -1,0 +1,6 @@
+[
+  {
+    "level": "WARN",
+    "message": "User already deleted, nothing to delete: id = 92f08b0a-4302-40ff-823d-b9ce18522552"
+  }
+]

--- a/src/test/resources/io/github/akuniutka/user/service/updateusertest/patch_with_old_values.json
+++ b/src/test/resources/io/github/akuniutka/user/service/updateusertest/patch_with_old_values.json
@@ -1,6 +1,6 @@
 [
   {
-    "level": "INFO",
-    "message": "No new data for user: id = 92f08b0a-4302-40ff-823d-b9ce18522552"
+    "level": "WARN",
+    "message": "No new data for user, nothing to update: id = 92f08b0a-4302-40ff-823d-b9ce18522552"
   }
 ]


### PR DESCRIPTION
Move initializing of user properties and marking a user as deleted from `UserServiceImpl` to new classes in order to separate data flow control from data transformations.

Also:
- Change logging level from `INFO` to `WARN` when updating a user and there is no new data in the update.
- Fix style of JavaDoc for `UserPatcher` interface.
- Make unit tests for `UserPatcherImpl` less specific.