### PR TITLE
Add CI-script to run tests on pull requests to main

### DIFF
--- a/.github/workflowa/tests.yaml
+++ b/.github/workflowa/tests.yaml
@@ -1,0 +1,20 @@
+name: CI tests
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo with pull request
+        uses: actions/checkout@v4
+
+      - name: set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - run: ./mvnw verify -P check,coverage


### PR DESCRIPTION
Add a GitHub Actions script to run unit and integrations tests on pull requests that target branch `main`.